### PR TITLE
Rename 'never_allow_redirects' option to 'never_redirect'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Overrides of Defaults
 This library allows to override some default values from the ``requests`` library
 that can have a security impact:
 
-- ``Config.never_allow_redirects = False`` always reject HTTP redirects
+- ``Config.never_redirect = False`` always reject HTTP redirects
 - ``Config.default_timeout = (2, 10)`` sets the default timeout value when no value or ``None`` is passed
 
 
@@ -43,7 +43,7 @@ Example Usage
   DefaultManager = Manager(
       Config(
           default_timeout=(2, 10),
-          never_allow_redirects=False,
+          never_redirect=False,
           ip_filter_enable=True,
           ip_filter_allow_localhost=False,
       )

--- a/requests_hardened/client.py
+++ b/requests_hardened/client.py
@@ -18,9 +18,9 @@ class HTTPSession(requests.Session):
 
     def send(self, request: PreparedRequest, **kwargs: Any) -> Response:
         allow_redirects = kwargs.setdefault(
-            "allow_redirects", not self._config.never_allow_redirects
+            "allow_redirects", not self._config.never_redirect
         )
-        if allow_redirects and self._config.never_allow_redirects:
+        if allow_redirects and self._config.never_redirect:
             kwargs["allow_redirects"] = False
 
         timeout = kwargs.setdefault("timeout", self._config.default_timeout)

--- a/requests_hardened/config.py
+++ b/requests_hardened/config.py
@@ -14,7 +14,7 @@ class Config:
     ip_filter_allow_localhost: bool
 
     # If True, then HTTP redirects are never allowed.
-    never_allow_redirects: bool
+    never_redirect: bool
 
     # The default timeout value to set to all requests.
     default_timeout: Optional[T_TIMEOUT_TUPLE]

--- a/tests/test_default_timeout.py
+++ b/tests/test_default_timeout.py
@@ -12,7 +12,7 @@ TimeoutManager = Manager(
         # irrelevant:
         ip_filter_enable=False,
         ip_filter_allow_localhost=True,
-        never_allow_redirects=False,
+        never_redirect=False,
     )
 )
 

--- a/tests/test_never_allow_redirects.py
+++ b/tests/test_never_allow_redirects.py
@@ -8,7 +8,7 @@ DEFAULT_TIMEOUT = (1, 2)
 
 NeverRedirectManager = Manager(
     Config(
-        never_allow_redirects=True,
+        never_redirect=True,
         # irrelevant:
         ip_filter_enable=False,
         ip_filter_allow_localhost=True,
@@ -17,7 +17,7 @@ NeverRedirectManager = Manager(
 )
 
 AllowRedirectManager = NeverRedirectManager.clone()
-AllowRedirectManager.config.never_allow_redirects = False
+AllowRedirectManager.config.never_redirect = False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -31,7 +31,7 @@ TEST_TIMEOUT_SECS = 5
 SSRFFilter = Manager(
     Config(
         default_timeout=SOCKET_TIMEOUT,
-        never_allow_redirects=False,
+        never_redirect=False,
         ip_filter_enable=True,
         ip_filter_allow_localhost=False,
     )


### PR DESCRIPTION
The option could potentially be confusing due combining negative and positive word ("never allow [...]")