### PR TITLE
Improve README.rst and project metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,20 @@
 requests-hardened
 =================
 
+|pypi-latest-version| |pypi-python-versions| |pypi-implementations|
+
+
 ``requests-hardened`` is a library that overrides the default behaviors of the ``requests``
 library, and adds new security features.
 
+Installation
+============
+
+The project is available on PyPI_:
+
+.. code-block::
+
+  pip install requests-hardened
 
 Features
 ========
@@ -57,3 +68,18 @@ Example Usage
   with DefaultManager.get_session() as sess:
       sess.request("GET", "https://example.com")
       sess.request("POST", "https://example.com", json={"foo": "bar"})
+
+
+.. _PyPI: https://pypi.org/project/requests-hardened
+
+.. |pypi-latest-version| image:: https://img.shields.io/pypi/v/requests-hardened.svg
+  :alt: Latest Version
+  :target: `PyPI`_
+
+.. |pypi-python-versions| image:: https://img.shields.io/pypi/pyversions/requests-hardened.svg
+  :alt: Supported Python Versions
+  :target: `PyPI`_
+
+.. |pypi-implementations| image:: https://img.shields.io/pypi/implementation/requests-hardened.svg
+  :alt: Supported Implementations
+  :target: `PyPI`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=61.0.0"]
 [project]
 name = "requests-hardened"
 readme = "README.rst"
-description = "A library that overrides the default behaviors of the ``requests`` library, and adds new security features."
+description = "A library that overrides the default behaviors of the requests library, and adds new security features."
 authors = [
     { name = "Saleor Commerce", email = "hello@saleor.io" }
 ]
@@ -39,10 +39,10 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://github.com/NyanKiyoshi/requests-hardened/"
-source = "https://github.com/NyanKiyoshi/requests-hardened/"
-issues = "https://github.com/NyanKiyoshi/requests-hardened/issues"
-changelog = "https://github.com/NyanKiyoshi/requests-hardened/releases/"
+Homepage = "https://github.com/saleor/requests-hardened/"
+Source = "https://github.com/saleor/requests-hardened/"
+Issues = "https://github.com/saleor/requests-hardened/issues"
+Changelog = "https://github.com/saleor/requests-hardened/releases/"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This adds PyPI information in README.rst as they are useful to quickly tell users how to install the project or where to find it.

This also improves the project metadata by renaming link names into "Title Case" which makes it more consistent with other PyPI projects, and with PyPI UI.

