### PR TITLE
Rename IP loopback filter setting

### DIFF
--- a/requests_hardened/client.py
+++ b/requests_hardened/client.py
@@ -45,7 +45,7 @@ class HTTPSession(requests.Session):
             url = filter_request(
                 url,
                 headers=headers,
-                allow_loopback=self._config.ip_filter_allow_localhost,
+                allow_loopback=self._config.ip_filter_allow_loopback_ips,
             )
             request.url = url
             request.headers = headers

--- a/requests_hardened/config.py
+++ b/requests_hardened/config.py
@@ -11,7 +11,7 @@ class Config:
 
     # If ``True``, then loopback IPs are allowed
     # when ``ip_filter_enable`` is set to ``True``.
-    ip_filter_allow_localhost: bool
+    ip_filter_allow_loopback_ips: bool
 
     # If True, then HTTP redirects are never allowed.
     never_redirect: bool

--- a/tests/test_default_timeout.py
+++ b/tests/test_default_timeout.py
@@ -11,7 +11,7 @@ TimeoutManager = Manager(
         default_timeout=DEFAULT_TIMEOUT,
         # irrelevant:
         ip_filter_enable=False,
-        ip_filter_allow_localhost=True,
+        ip_filter_allow_loopback_ips=True,
         never_redirect=False,
     )
 )

--- a/tests/test_never_allow_redirects.py
+++ b/tests/test_never_allow_redirects.py
@@ -11,7 +11,7 @@ NeverRedirectManager = Manager(
         never_redirect=True,
         # irrelevant:
         ip_filter_enable=False,
-        ip_filter_allow_localhost=True,
+        ip_filter_allow_loopback_ips=True,
         default_timeout=(1, 1),
     )
 )

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -33,12 +33,12 @@ SSRFFilter = Manager(
         default_timeout=SOCKET_TIMEOUT,
         never_redirect=False,
         ip_filter_enable=True,
-        ip_filter_allow_localhost=False,
+        ip_filter_allow_loopback_ips=False,
     )
 )
 
 SSRFFilterAllowLocalHost = SSRFFilter.clone()
-SSRFFilterAllowLocalHost.config.ip_filter_allow_localhost = True
+SSRFFilterAllowLocalHost.config.ip_filter_allow_loopback_ips = True
 
 
 @pytest.mark.parametrize(
@@ -170,7 +170,7 @@ def test_url_handling(
     expected_http_host_header: str,
 ):
     manager = SSRFFilter.clone()
-    manager.config.ip_filter_allow_localhost = True
+    manager.config.ip_filter_allow_loopback_ips = True
     with mock_getaddrinfo(resolves_to):
         manager.send_request("GET", input_url)
 


### PR DESCRIPTION
The setting `ip_filter_allow_localhost` is misleading as it sounds like it only allows/rejects `127.0.0.1` whereas it filters loopback IPs (i.e. 127.0.0.0 to 127.255.255.255).