### PR TITLE
add custom `User-Agent` header to `Config`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ that can have a security impact:
 
 - ``Config.never_redirect = False`` always reject HTTP redirects
 - ``Config.default_timeout = (2, 10)`` sets the default timeout value when no value or ``None`` is passed
-
+- ``Config.user_agent_override = None`` optional config to override ``User-Agent`` header. When set to ``None``, ``requests`` library will set its `default user-agent <https://github.com/psf/requests/blob/ee93fac6b2f715151f1aa9a1a06ddba9f7dcc59a/src/requests/utils.py#L886-L892>`_.
 
 SSRF Filters
 ------------
@@ -57,6 +57,7 @@ Example Usage
           never_redirect=False,
           ip_filter_enable=True,
           ip_filter_allow_localhost=False,
+          user_agent_override=None
       )
   )
 

--- a/requests_hardened/client.py
+++ b/requests_hardened/client.py
@@ -30,14 +30,11 @@ class HTTPSession(requests.Session):
 
     def prepare_request(self, request: Request) -> PreparedRequest:
         url = request.url
-
         if self._config.ip_filter_enable is True:
             headers = request.headers or {}
-
             # Cast potentially immutable header list to `dict`
             if not isinstance(headers, dict):
                 headers = cast(dict, dict(**headers))
-
             # Cast `bytes` to `str`
             if isinstance(url, bytes):
                 url = url.decode()
@@ -49,4 +46,6 @@ class HTTPSession(requests.Session):
             )
             request.url = url
             request.headers = headers
+        if self._config.user_agent_override is not None:
+            request.headers.update({"User-Agent": self._config.user_agent_override})
         return super().prepare_request(request)

--- a/requests_hardened/config.py
+++ b/requests_hardened/config.py
@@ -18,3 +18,6 @@ class Config:
 
     # The default timeout value to set to all requests.
     default_timeout: Optional[T_TIMEOUT_TUPLE]
+
+    # Override the default User-Agent header of the requests library.
+    user_agent_override: Optional[str] = None

--- a/tests/test_never_allow_redirects.py
+++ b/tests/test_never_allow_redirects.py
@@ -13,6 +13,7 @@ NeverRedirectManager = Manager(
         ip_filter_enable=False,
         ip_filter_allow_loopback_ips=True,
         default_timeout=(1, 1),
+        user_agent_override="user-agent",
     )
 )
 

--- a/tests/test_override_user_agent_header.py
+++ b/tests/test_override_user_agent_header.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import pytest
+
+import requests
+
+from requests_hardened import Manager, Config
+
+
+UserAgentNotDefinedManager = Manager(
+    Config(
+        # irrelevant:
+        never_redirect=True,
+        ip_filter_enable=False,
+        ip_filter_allow_loopback_ips=True,
+        default_timeout=(1, 1),
+    )
+)
+UserAgentDefinedManager = UserAgentNotDefinedManager.clone()
+UserAgentDefinedManager.config.user_agent_override = None
+
+
+@pytest.mark.parametrize("user_agent", ["user-agent", ""])
+@mock.patch("requests.sessions.Session.send")
+def test_user_agent_override_config(mocked_send: mock.MagicMock, user_agent):
+    UserAgentDefinedManager.config.user_agent_override = user_agent
+    UserAgentDefinedManager.send_request("GET", "https://example.com")
+
+    prep_request = mocked_send.call_args[0][0]
+
+    assert mocked_send.assert_called_once
+    assert prep_request.headers.get("User-Agent") == user_agent
+
+
+@mock.patch("requests.sessions.Session.send")
+def test_user_agent_override_none(mocked_send: mock.MagicMock):
+    UserAgentDefinedManager.config.user_agent_override = None
+    UserAgentDefinedManager.send_request("GET", "https://example.com")
+
+    prep_request = mocked_send.call_args[0][0]
+
+    assert mocked_send.assert_called_once
+    assert prep_request.headers.get("User-Agent") == f"python-requests/{requests.__version__}"
+
+
+@mock.patch("requests.sessions.Session.send")
+def test_user_agent_override_undefined(mocked_send: mock.MagicMock):
+    UserAgentNotDefinedManager.send_request("GET", "https://example.com")
+
+    prep_request = mocked_send.call_args[0][0]
+    assert mocked_send.assert_called_once
+    assert prep_request.headers.get("User-Agent") == f"python-requests/{requests.__version__}"

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -34,6 +34,7 @@ SSRFFilter = Manager(
         never_redirect=False,
         ip_filter_enable=True,
         ip_filter_allow_loopback_ips=False,
+        user_agent_override="user-agent",
     )
 )
 


### PR DESCRIPTION
Allow easy override of the User-Agent header with the Config class.