### PR TITLE
Bump version to v1.0.0b2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.8"
-version = "1.0.0b1"
+version = "1.0.0b2"
 dependencies = [
     'requests>=2.0.1,<3.0.0'
 ]


### PR DESCRIPTION
This will release the latest changes since v1.0.0b1:

- add 'user_agent_override' option to override the default 'User-Agent' header (https://github.com/saleor/requests-hardened/pull/8)