### PR TITLE
Bump cffi to fix tests workflow on Windows when using PyPy

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@
 #
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
 charset-normalizer==3.2.0
     # via requests


### PR DESCRIPTION
Fixes issue when installing `cffi` on windows-latest using PyPy (https://github.com/saleor/requests-hardened/actions/runs/8554053433).

Dependency chain: `cffi` <- `cryptography` <- `trustme`.

There is no newer version of `trustme` available (that would depend on newer `cryptography` that would depend on newer `cffi`) so I had to resort to bumping `cffi` dependency manually in a file that is generated automatically.