### PR TITLE
Update outdated usage in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ IP addresses.
 Settings:
 
 - ``Config.ip_filter_enable`` whether or not to filter the IP addresses
-- ``ip_filter_allow_localhost`` whether or not to allow loopback IP addresses
+- ``ip_filter_allow_loopback_ips`` whether or not to allow loopback IP addresses
 
 
 Example Usage
@@ -56,7 +56,7 @@ Example Usage
           default_timeout=(2, 10),
           never_redirect=False,
           ip_filter_enable=True,
-          ip_filter_allow_localhost=False,
+          ip_filter_allow_loopback_ips=False,
           user_agent_override=None
       )
   )


### PR DESCRIPTION
20b8b9a067e1da646736b6d349ca1d11dac7ead7 renamed `ip_filter_allow_localhost` to `ip_filter_allow_loopback_ips` but didn't update the docs which led to the following error:

```
TypeError                                 Traceback (most recent call last)
Cell In[2], line 2
      1 DefaultManager = Manager(
----> 2     Config(
      3         default_timeout=(2, 10),
      4         never_redirect=False,
      5         ip_filter_enable=True,
      6         ip_filter_allow_localhost=False,
      7         user_agent_override=None
      8     )
      9 )

TypeError: __init__() got an unexpected keyword argument 'ip_filter_allow_localhost'
```