### PR TITLE
Handle socket exceptions during IP resolution failures

### DIFF
--- a/requests_hardened/ip_filter.py
+++ b/requests_hardened/ip_filter.py
@@ -4,6 +4,7 @@ import socket
 from typing import Dict, Tuple, Union
 
 import requests
+from requests.exceptions import InvalidURL
 from urllib3.util import Url, parse_url
 from urllib3.util.connection import (  # type: ignore[attr-defined] # `allowed_gai_family` exists. # noqa: E501
     allowed_gai_family,
@@ -65,33 +66,47 @@ def get_ip_address(
 def filter_request(
     url: str, *, headers: Dict[str, Union[str, bytes, None]], allow_loopback: bool
 ) -> str:
-    url = parse_url(url)
-    port = url.port
+    try:
+        parsed_url = parse_url(url)
+    except ValueError as exc:
+        raise InvalidURL from exc
+
+    port = parsed_url.port
 
     if not port:
-        if url.scheme == "https":
+        if parsed_url.scheme == "https":
             port = 443
         else:
             port = 80
 
     # IPv6 URL hostnames are embedded between "[" and "]"
-    old_hostname = url.hostname
+    old_hostname = parsed_url.hostname
     if not old_hostname:
         raise ValueError("Invalid URL: missing hostname")
     if old_hostname.startswith("["):
         old_hostname = old_hostname.strip("[]")
 
     headers["Host"] = old_hostname
-    ip_addr, port = get_ip_address(old_hostname, port, allow_loopback=allow_loopback)
+
+    try:
+        ip_addr, port = get_ip_address(
+            old_hostname, port, allow_loopback=allow_loopback
+        )
+    except socket.gaierror as exc:
+        raise requests.ConnectionError("Failed to resolve domain") from exc
+    except socket.timeout as exc:
+        raise requests.ConnectTimeout("Failed to connect to host") from exc
+
     ip_addr_str = str(ip_addr) if ip_addr.version != 6 else f"[{ip_addr}]"
 
-    url = Url(
-        scheme=url.scheme,
-        auth=url.auth,
-        host=ip_addr_str,
-        port=port,
-        path=url.path,
-        query=url.query,
-        fragment=url.fragment,
+    return str(
+        Url(
+            scheme=parsed_url.scheme,
+            auth=parsed_url.auth,
+            host=ip_addr_str,
+            port=port,
+            path=parsed_url.path,
+            query=parsed_url.query,
+            fragment=parsed_url.fragment,
+        )
     )
-    return str(url)

--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -1,0 +1,34 @@
+import socket
+import requests
+from unittest import mock
+
+from requests_hardened.ip_filter import filter_request
+
+
+@mock.patch("requests_hardened.ip_filter.parse_url")
+def test_filter_request_handles_parse_url_raise_invalid_url(parse_url_mock):
+    parse_url_mock.side_effect = ValueError
+    try:
+        filter_request("improper_addr", headers={}, allow_loopback=False)
+    except requests.exceptions.InvalidURL as e:
+        assert str(e) == ""
+
+
+@mock.patch("requests_hardened.ip_filter.get_ip_address")
+def test_filter_request_failed_to_resolve_domain_raise_connection_error(
+    get_ip_address_mock,
+):
+    get_ip_address_mock.side_effect = socket.gaierror
+    try:
+        filter_request("https://example.com", headers={}, allow_loopback=False)
+    except requests.ConnectionError as e:
+        assert str(e) == "Failed to resolve domain"
+
+
+@mock.patch("requests_hardened.ip_filter.get_ip_address")
+def test_filter_request_timeout_raise_timeout_error(get_ip_address_mock):
+    get_ip_address_mock.side_effect = socket.timeout
+    try:
+        filter_request("https://example.com", headers={}, allow_loopback=False)
+    except requests.ConnectionError as e:
+        assert str(e) == "Failed to connect to host"

--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -1,6 +1,7 @@
-import socket
-import requests
 import pytest
+import requests
+import socket
+from requests.exceptions import InvalidURL
 from unittest import mock
 
 from requests_hardened.ip_filter import filter_request
@@ -9,7 +10,7 @@ from requests_hardened.ip_filter import filter_request
 @mock.patch("requests_hardened.ip_filter.parse_url")
 def test_filter_request_handles_parse_url_raise_invalid_url(parse_url_mock):
     parse_url_mock.side_effect = ValueError
-    with pytest.raises(requests.exceptions.InvalidURL):
+    with pytest.raises(InvalidURL):
         filter_request("improper_addr", headers={}, allow_loopback=False)
 
 

--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -7,24 +7,25 @@ from unittest import mock
 from requests_hardened.ip_filter import filter_request
 
 
-@mock.patch("requests_hardened.ip_filter.parse_url")
-def test_filter_request_handles_parse_url_raise_invalid_url(parse_url_mock):
-    parse_url_mock.side_effect = ValueError
+def test_filter_request_handles_parse_url_raise_invalid_url():
     with pytest.raises(InvalidURL):
-        filter_request("improper_addr", headers={}, allow_loopback=False)
+        filter_request("00000001:0000C2934AB1", headers={}, allow_loopback=False)
 
 
-@mock.patch("requests_hardened.ip_filter.get_ip_address")
-def test_filter_request_failed_to_resolve_domain_raise_connection_error(
-    get_ip_address_mock,
+@mock.patch("requests_hardened.ip_filter.socket.getaddrinfo")
+def test_filter_request_raise_connection_error_on_invalid_address_family(
+    getaddrinfo_mock,
 ):
-    get_ip_address_mock.side_effect = socket.gaierror
-    with pytest.raises(requests.ConnectionError, match="Failed to resolve domain"):
+    getaddrinfo_mock.side_effect = socket.gaierror
+    with pytest.raises(
+        requests.ConnectionError,
+        match="Failed to resolve domain",
+    ):
         filter_request("https://example.com", headers={}, allow_loopback=False)
 
 
-@mock.patch("requests_hardened.ip_filter.get_ip_address")
-def test_filter_request_timeout_raise_timeout_error(get_ip_address_mock):
-    get_ip_address_mock.side_effect = socket.timeout
-    with pytest.raises(requests.ConnectionError, match="Failed to connect to host"):
+@mock.patch("requests_hardened.ip_filter.socket.getaddrinfo")
+def test_filter_request_timeout_raise_timeout_error(getaddrinfo_mock):
+    getaddrinfo_mock.side_effect = socket.timeout
+    with pytest.raises(requests.ConnectTimeout, match="Failed to connect to host"):
         filter_request("https://example.com", headers={}, allow_loopback=False)

--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -1,5 +1,6 @@
 import socket
 import requests
+import pytest
 from unittest import mock
 
 from requests_hardened.ip_filter import filter_request
@@ -8,10 +9,8 @@ from requests_hardened.ip_filter import filter_request
 @mock.patch("requests_hardened.ip_filter.parse_url")
 def test_filter_request_handles_parse_url_raise_invalid_url(parse_url_mock):
     parse_url_mock.side_effect = ValueError
-    try:
+    with pytest.raises(requests.exceptions.InvalidURL):
         filter_request("improper_addr", headers={}, allow_loopback=False)
-    except requests.exceptions.InvalidURL as e:
-        assert str(e) == ""
 
 
 @mock.patch("requests_hardened.ip_filter.get_ip_address")
@@ -19,16 +18,12 @@ def test_filter_request_failed_to_resolve_domain_raise_connection_error(
     get_ip_address_mock,
 ):
     get_ip_address_mock.side_effect = socket.gaierror
-    try:
+    with pytest.raises(requests.ConnectionError, match="Failed to resolve domain"):
         filter_request("https://example.com", headers={}, allow_loopback=False)
-    except requests.ConnectionError as e:
-        assert str(e) == "Failed to resolve domain"
 
 
 @mock.patch("requests_hardened.ip_filter.get_ip_address")
 def test_filter_request_timeout_raise_timeout_error(get_ip_address_mock):
     get_ip_address_mock.side_effect = socket.timeout
-    try:
+    with pytest.raises(requests.ConnectionError, match="Failed to connect to host"):
         filter_request("https://example.com", headers={}, allow_loopback=False)
-    except requests.ConnectionError as e:
-        assert str(e) == "Failed to connect to host"


### PR DESCRIPTION
This handles `get_ip_address()` exceptions by wrapping them by `requests.exceptions.RequestException`.

- Handles invalid URLs (replaced ValueError)
- Handles OSError on socket creation
- Handles gaierror for resolution failures
- Handles timeout for failures to connect to the DNS server in time.