### PR TITLE
Bump project version to v1.0.0b5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     "Saleor Commerce <hello@saleor.io>"
 ]
 license = "BSD-3-Clause"
-version = "1.0.0b4"
+version = "1.0.0b5"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
This changes the project version from v1.0.0b4 to v1.0.0b5.

Changes that will be released:
- Switch from pip-tools to Poetry
- Removal of URL rewrites from the IP filtering feature in favor of socket-level IP address pinning