### PR TITLE
codeql: fix missing minimum TLS version in tests

### DIFF
--- a/tests/http_test_servers/tls.py
+++ b/tests/http_test_servers/tls.py
@@ -8,6 +8,7 @@ from http.server import HTTPServer
 import trustme
 
 from .insecure import InsecureHTTPTestServer
+from ..utils import create_ssl_context
 
 
 class TLSTestServer(InsecureHTTPTestServer):
@@ -69,7 +70,7 @@ class TLSTestServer(InsecureHTTPTestServer):
 
     @staticmethod
     def create_ssl_context(server_cert: trustme.LeafCert):
-        ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ssl_context = create_ssl_context(ssl.Purpose.CLIENT_AUTH)
         server_cert.configure_cert(ssl_context)
         return ssl_context
 

--- a/tests/test_dummy_sni_tls_server.py
+++ b/tests/test_dummy_sni_tls_server.py
@@ -1,9 +1,7 @@
-import ssl
-
 import pytest
 
 from tests.http_test_servers import SNITLSHTTPTestServer
-from tests.utils import get_remote_certificate
+from tests.utils import get_remote_certificate, create_ssl_context
 
 
 @pytest.mark.enable_socket # We need to be able to create the dummy server
@@ -25,7 +23,7 @@ def test_dummy_sni_tls_server(tmp_path):
     )
 
     with srv as sock_addr:
-        ssl_ctx = ssl.create_default_context()
+        ssl_ctx = create_ssl_context()
         ssl_ctx.load_verify_locations(srv.ca_bundle_path)
 
         # Retrieve the default TLS certificate (not an SNI callback one).

--- a/tests/test_dummy_tls_server.py
+++ b/tests/test_dummy_tls_server.py
@@ -1,9 +1,7 @@
-import ssl
-
 import pytest
 
 from tests.http_test_servers import TLSTestServer
-from tests.utils import get_remote_certificate
+from tests.utils import get_remote_certificate, create_ssl_context
 
 
 @pytest.mark.enable_socket # We need to be able to create the dummy server
@@ -19,7 +17,7 @@ def test_dummy_tls_server(tmp_path):
     srv = TLSTestServer(tmp_path, cert_identities=[fqn], cert_options={})
 
     with srv as sock_addr:
-        ssl_ctx = ssl.create_default_context()
+        ssl_ctx = create_ssl_context()
         ssl_ctx.load_verify_locations(srv.ca_bundle_path)
 
         # Get the certificate a domain that is associated with the server's

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,12 @@ from typing import List, Tuple, Optional, Generator
 from unittest import mock
 
 
+def create_ssl_context(purpose=ssl.Purpose.SERVER_AUTH) -> ssl.SSLContext:
+    ctx = ssl.create_default_context(purpose)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+    return ctx
+
+
 @contextlib.contextmanager
 def create_ssl_socket(
     ssl_ctx: ssl.SSLContext, addr: Tuple[str, int], server_hostname: str


### PR DESCRIPTION
CodeQL was reporting some tests were not configured to use secure TLS version (TLS_1.2+), this commit fixes the issue.

There is no real impact due to being only test-specific code.

Reference: https://codeql.github.com/codeql-query-help/python/py-insecure-default-protocol/