### PR TITLE
deps: update supported Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
           - "pypy3.9"
           - "pypy3.10"
         os:

--- a/poetry.lock
+++ b/poetry.lock
@@ -504,13 +504,13 @@ files = [
 
 [[package]]
 name = "trustme"
-version = "1.1.0"
+version = "1.2.0"
 description = "#1 quality TLS certs while you wait, for the discerning tester"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "trustme-1.1.0-py3-none-any.whl", hash = "sha256:ce105b68fb9f6d7ac7a9ee6e95bb2347a22ce4d3be78ef9a6494d5ef890e1e16"},
-    {file = "trustme-1.1.0.tar.gz", hash = "sha256:5375ad7fb427074bec956592e0d4ee2a4cf4da68934e1ba4bcf4217126bc45e6"},
+    {file = "trustme-1.2.0-py3-none-any.whl", hash = "sha256:32bf1fe9f63804e4243ae01dcab7765163abae4376aed5726a1560d21dfb3abc"},
+    {file = "trustme-1.2.0.tar.gz", hash = "sha256:ed2264fb46c35459e6de9e454ed4bab73be44b6a2a26ad417f9b6854aebb644a"},
 ]
 
 [package.dependencies]
@@ -561,5 +561,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<4.0"
-content-hash = "8ae81360dde862e93415bf88211869d336f00ca18e00bb5e8f5f231602785c17"
+python-versions = ">=3.9,<4.0"
+content-hash = "c546cf6088b257d9e3f3ed8fdae768c323b1c3d92618f72e9b946eb4700ce8b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -41,7 +41,7 @@ Issues = "https://github.com/saleor/requests-hardened/issues"
 Changelog = "https://github.com/saleor/requests-hardened/releases/"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 # We require >=2.32.3 due to depending on `get_connection_with_tls_context`.
 requests = ">=2.32.3,<3.0.0"
 


### PR DESCRIPTION
- Removes support for Python 3.8 due to being EOL since Oct. 2024
- Adds support for Python 3.13 (released Oct. 2024)