### PR TITLE
tests: add comments to ip filtering error handling

### DIFF
--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -10,8 +10,10 @@ from requests_hardened.ip_filter import filter_host
 def test_filter_request_raise_connection_error_on_invalid_address_family(
     getaddrinfo_mock,
 ):
+    """Ensures address resolution failures from getaddrinfo() are handled (gaierror)"""
     getaddrinfo_mock.side_effect = socket.gaierror
     with pytest.raises(
+        # Error should be wrapped with `requests.ConnectionError`
         requests.ConnectionError,
         match="Failed to resolve domain",
     ):
@@ -20,6 +22,13 @@ def test_filter_request_raise_connection_error_on_invalid_address_family(
 
 @mock.patch("requests_hardened.ip_filter.socket.getaddrinfo")
 def test_filter_request_timeout_raise_timeout_error(getaddrinfo_mock):
+    """
+    Ensures timeouts in address resolution from getaddrinfo() are handled (socket.timeout)
+    """
     getaddrinfo_mock.side_effect = socket.timeout
-    with pytest.raises(requests.ConnectTimeout, match="Failed to connect to host"):
+    with pytest.raises(
+        # Error should be wrapped with `requests.ConnectionError`
+        requests.ConnectTimeout,
+        match="Failed to connect to host"
+    ):
         filter_host("example.com", 443, allow_loopback=False)


### PR DESCRIPTION
535dc1750b6cd848b75feba098654c22ddd0fc9e added tests for ensuring errors from `getaddrinfo()` are properly handled and wrapped but the tests did not contain any comments to help quickly understand.

This commit adds comments in order to help maintainers to quickly understand the intent.