### PR TITLE
feat: add official support for proxies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} @ ${{ matrix.python-version }}
+    # A lot wiggle room is needed due to:
+    # - PyPI can occasionally slow down.
+    # - MacOS and Windows machines can sometimes be slower than the Linux ones.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -52,4 +56,7 @@ jobs:
           python -m poetry install
 
       - name: Run Tests
+        # Tests should takes only a few seconds to run.
+        # If it takes several minutes, then something is stuck.
+        timeout-minutes: 5
         run: pytest tests/

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -1,0 +1,107 @@
+=================
+Development Guide
+=================
+
+The purpose of this document is to share knowledge surrounding the development of this
+library in order to make the development process easier for new comers.
+
+Using Proxies
+=============
+
+The library supports using proxies, such as in the IP filtering feature,
+this section describes how to start a proxy server and how to use it.
+
+Running a Proxy Server
+----------------------
+
+You can start a proxy using one of these options:
+
+Using pproxy
+^^^^^^^^^^^^
+
+The `pproxy`_ command comes pre-installed as part of the development dependencies
+(``poetry install --with dev``).
+
+.. note::
+
+  In these examples, we will use ``127.0.0.1:8888`` as the proxy address.
+
+To start a server with the multiple protocols (HTTP, SOCKS4, SOCKS5), run:
+
+.. code-block:: bash
+
+  pproxy -l 'http+socks4+socks5://127.0.0.1:8888/'
+
+Alternatively, you can select a single protocol. For example, if you only want SOCKS5:
+
+.. code-block:: bash
+
+  pproxy -l 'socks5://127.0.0.1:8888/'
+
+Using SSH
+^^^^^^^^^
+
+You can start a SOCKS4 and SOCKS5 proxy using the following SSH command:
+
+.. code-block:: bash
+
+  ssh user@example.com -D 127.0.0.1:8888
+
+Using the Proxy Server
+----------------------
+
+.. note::
+
+  You will find more details inside the ``requests`` `documentation <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`_
+
+Once you have a `proxy running in the background <Running a Proxy Server_>`_,
+you can tell requests-hardened to use it using either of these methods:
+
+Using Environment Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Using ``HTTP_PROXY`` and ``HTTPS_PROXY``:
+
+.. code-block:: bash
+
+  $ export HTTP_PROXY="socks5://127.0.0.1:8888"
+  $ export HTTPS_PROXY="socks5://127.0.0.1:8888"
+  $ python3 my-script.py
+
+Alternatively, using ``ALL_PROXY``:
+
+.. code-block:: bash
+
+  $ export ALL_PROXY="socks5://127.0.0.1:8888"
+  $ python3 my-script.py
+
+Using the ``proxies={...}`` Keyword (Python Code)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``requests`` libraries allows to define proxies servers to be used via the ``proxies``
+parameter.
+
+Example:
+
+.. code-block:: python
+
+  from requests_hardened import Config, Manager
+
+  http_manager = Manager(
+      Config(
+          ip_filter_enable=True,
+          ip_filter_allow_loopback_ips=True,
+          never_redirect=False,
+          default_timeout=2,
+      )
+  )
+
+  proxies = {
+    "http": "socks5://127.0.0.1:8888",
+    "https": "socks5://127.0.0.1:8888",
+  }
+
+  http_manager.send_request("GET", "https://example.com", proxies=proxies)
+
+
+.. _pproxy: https://github.com/qwj/python-proxy/

--- a/poetry.lock
+++ b/poetry.lock
@@ -394,6 +394,22 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pproxy"
+version = "2.7.9"
+description = "Proxy server that can tunnel among remote servers by regex rules."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pproxy-2.7.9-py3-none-any.whl", hash = "sha256:a073d02616a47c43e1d20a547918c307dbda598c6d53869b165025f3cfe58e80"},
+]
+
+[package.extras]
+accelerated = ["pycryptodome (>=3.7.2)", "uvloop (>=0.13.0)"]
+daemon = ["python-daemon (>=2.2.3)"]
+quic = ["aioquic (>=0.9.7)"]
+sshtunnel = ["asyncssh (>=2.5.0)"]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -402,6 +418,18 @@ python-versions = ">=3.8"
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
 ]
 
 [[package]]
@@ -455,6 +483,7 @@ files = [
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
+PySocks = {version = ">=1.5.6,<1.5.7 || >1.5.7", optional = true, markers = "extra == \"socks\""}
 urllib3 = ">=1.21.1,<3"
 
 [package.extras]
@@ -562,4 +591,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "c546cf6088b257d9e3f3ed8fdae768c323b1c3d92618f72e9b946eb4700ce8b4"
+content-hash = "2638864222286c2723b97bb223086a2f51f012e2d89bede4bce96ffd6631c367"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ mypy = "^1.5.1"
 types-requests = ">=2.32.0,<3.0.0"
 trustme = ">=1.1.0,<2.0.0"
 pytest-socket = "^0.7.0"
+pproxy = "^2.7.9"
+requests = { version = ">=2.32.3,<3.0.0" , extras = ["socks"] }
 
 [tool.setuptools]
 zip-safe = false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ from tests.utils import mock_getaddrinfo
 
 FAKE_RESOLVER_MARKER = "fake_resolver"
 
+pytest_plugins = [
+    # Additional fixtures for the test suite.
+    "tests.proxy_test_servers.fixtures"
+]
+
 
 @pytest.mark.tryfirst
 def pytest_load_initial_conftests(early_config, parser, args):

--- a/tests/http_managers.py
+++ b/tests/http_managers.py
@@ -1,0 +1,18 @@
+from requests_hardened import Config, Manager
+
+# HTTP server can take some time to connect against for some machines (usually up to 1s).
+# It requires a fairly generous timeout without taking too long that the test fails.
+SOCKET_TIMEOUT = (4, 0.1)
+
+SSRFFilter = Manager(
+    Config(
+        default_timeout=SOCKET_TIMEOUT,
+        never_redirect=False,
+        ip_filter_enable=True,
+        ip_filter_allow_loopback_ips=False,
+        user_agent_override="user-agent",
+    )
+)
+
+SSRFFilterAllowLocalHost = SSRFFilter.clone()
+SSRFFilterAllowLocalHost.config.ip_filter_allow_loopback_ips = True

--- a/tests/proxy_test_servers/fixtures.py
+++ b/tests/proxy_test_servers/fixtures.py
@@ -1,0 +1,53 @@
+import contextlib
+import multiprocessing
+
+import pytest
+
+from tests.proxy_test_servers.server import run_worker
+
+
+@contextlib.contextmanager
+def create_dummy_proxy(proto: str) -> str:
+    """
+    Create a dummy proxy server and listens on a random port (port=0).
+    """
+
+    # Queue to wait and retrieve the address the server bound to.
+    queue_bound_addr = multiprocessing.Queue()
+
+    # Starts the proxy as a sub-process instead of a thread as it may otherwise
+    # lead to issues due to using asyncio.
+    proc = multiprocessing.Process(target=run_worker, args=(proto, queue_bound_addr))
+    proc.start()
+
+    # Retrieve the ("randomly") bound port number and return it
+    [hostname, port] = queue_bound_addr.get()
+    yield f"{proto}://{hostname}:{port}"
+
+    # Shutdown
+    proc.terminate()
+    proc.join()
+
+
+@pytest.fixture(scope="session")
+def dummy_proxy_socks4() -> str:
+    """Dummy SOCKS4 proxy server."""
+
+    with create_dummy_proxy("socks4") as url:
+        yield url
+
+
+@pytest.fixture(scope="session")
+def dummy_proxy_socks5() -> str:
+    """Dummy SOCKS5 proxy server."""
+
+    with create_dummy_proxy("socks5") as url:
+        yield url
+
+
+@pytest.fixture(scope="session")
+def dummy_proxy_http() -> str:
+    """Dummy HTTP proxy server (`CONNECT` HTTP verb)."""
+
+    with create_dummy_proxy("http") as url:
+        yield url

--- a/tests/proxy_test_servers/fixtures.py
+++ b/tests/proxy_test_servers/fixtures.py
@@ -10,6 +10,8 @@ from tests.proxy_test_servers.server import run_worker
 def create_dummy_proxy(proto: str) -> str:
     """
     Create a dummy proxy server and listens on a random port (port=0).
+
+    :return: the proxy URL.
     """
 
     # Queue to wait and retrieve the address the server bound to.

--- a/tests/proxy_test_servers/fixtures.py
+++ b/tests/proxy_test_servers/fixtures.py
@@ -21,7 +21,7 @@ def create_dummy_proxy(proto: str) -> str:
     proc.start()
 
     # Retrieve the ("randomly") bound port number and return it
-    [hostname, port] = queue_bound_addr.get()
+    [hostname, port] = queue_bound_addr.get(timeout=5)
     yield f"{proto}://{hostname}:{port}"
 
     # Shutdown

--- a/tests/proxy_test_servers/server.py
+++ b/tests/proxy_test_servers/server.py
@@ -17,12 +17,6 @@ from pproxy.server import ProxySimple
 
 logger = logging.getLogger(__name__)
 
-supported_protocols = (
-    "http",  # HTTP protocol using the CONNECT HTTP method to establish a tunnel.
-    "socks4",
-    "socks5",
-)
-
 
 class DummyProxyServer:
     def __init__(self, protocol: str, bind_addr: Optional[Tuple[str, int]] = None):
@@ -67,7 +61,7 @@ class DummyProxyServer:
         # `getsockname()` in order to determine which port was allocated to us.
         #
         # After which, we validate whether the value is (host: str, port: int)
-        # due to having the "Any".
+        # due to having the "Any" type.
         addr: socket.socket = self.handler.sockets[0].getsockname()
         assert isinstance(addr, tuple), "Expected a tuple of (host, port)"
         assert len(addr) == 2, "Expected a 2-tuple with only (host, port)"

--- a/tests/proxy_test_servers/server.py
+++ b/tests/proxy_test_servers/server.py
@@ -141,7 +141,7 @@ def run_worker(
     ... )
     ...
     >>> proc.start()
-    >>> addr = callback_queue.get()
+    >>> addr = callback_queue.get(timeout=5)
     >>> print(f"Listening on: {proto}://{addr[0]}:{addr[1]}")
     >>>
     >>> # Keep the server running for 30s.

--- a/tests/proxy_test_servers/server.py
+++ b/tests/proxy_test_servers/server.py
@@ -1,0 +1,157 @@
+"""
+This file creates a dummy proxy server (using HTTP, SOCKS4 and SOCKS5 protocols),
+it uses the 'pproxy' library for it (https://github.com/qwj/python-proxy/).
+
+As a precaution to unintended side effects, the server is started inside a child
+process to fully isolate it from the main process (through the `multiprocessing` stdlib).
+"""
+
+import asyncio
+import logging
+import multiprocessing
+import socket
+from typing import Optional, Tuple
+
+import pproxy
+from pproxy.server import ProxySimple
+
+logger = logging.getLogger(__name__)
+
+supported_protocols = (
+    "http",  # HTTP protocol using the CONNECT HTTP method to establish a tunnel.
+    "socks4",
+    "socks5",
+)
+
+
+class DummyProxyServer:
+    def __init__(self, protocol: str, bind_addr: Optional[Tuple[str, int]] = None):
+        self._protocol = protocol
+
+        if bind_addr is not None:
+            self._addr = bind_addr
+        else:
+            self._addr = ("127.0.0.1", 0)
+
+        self.loop = asyncio.get_event_loop()
+        self.handler: Optional[asyncio.Server] = None
+
+    def start(self) -> (str, int):
+        server: ProxySimple = pproxy.Server(
+            f"{self._protocol}://{self._addr[0]}:{self._addr[1]}"
+        )
+
+        self.handler: asyncio.Server = self.loop.run_until_complete(
+            server.start_server(
+                {
+                    "rserver": [],  # Direct connection (no multi-hop setup)
+                    # Redirects verbose logging to `logger.debug()` in order to make
+                    # the tests quiet by default.
+                    #
+                    # The 'verbose' argument isn't designed to be passed
+                    # to `logging` thus may pose threats if there are untrusted inputs
+                    # (e.g., verbose("arbitrary user-provided value: %(x)999999999999s").
+                    #
+                    # As a best practice, we thus put the message as "%s"
+                    # in order to tell the `logging` module to not try to format
+                    # the arguments (and thus making it consider it as untrusted input).
+                    "verbose": lambda *args: logger.debug("%s", " ".join(args)),
+                }
+            )
+        )
+
+        assert len(self.handler.sockets) == 1, "Expected only one socket to be created"
+
+        # Retrieve the socket address. This is needed as port=0 will allocate
+        # an unused ephemeral port upon bind, thus we need to run the syscall
+        # `getsockname()` in order to determine which port was allocated to us.
+        #
+        # After which, we validate whether the value is (host: str, port: int)
+        # due to having the "Any".
+        addr: socket.socket = self.handler.sockets[0].getsockname()
+        assert isinstance(addr, tuple), "Expected a tuple of (host, port)"
+        assert len(addr) == 2, "Expected a 2-tuple with only (host, port)"
+        assert isinstance(addr[0], str), "Expected bind hostname to be a string"
+        assert isinstance(addr[1], int), "Expected bind port to be an integer"
+
+        # Update the server address with the newly bound port.
+        self._addr = addr
+        return addr
+
+    def serve_forever(self):
+        if self.handler is None:
+            raise RuntimeError(
+                f"Server was not started: "
+                f"{self.__class__.__name__}.start() was never called"
+            )
+        try:
+            # Stopped by `loop.stop()`
+            self.loop.run_forever()
+        finally:
+            self.handler.close()
+            self.loop.run_until_complete(self.handler.wait_closed())
+
+    def shutdown(self):
+        # Stop the asyncio loop, this will cause ``serve_forever`` to exit.
+        self.loop.stop()
+
+        if self.handler is not None:
+            self.loop.run_until_complete(self.handler.wait_closed())
+
+        self.loop.run_until_complete(self.loop.shutdown_asyncgens())
+
+    def __enter__(self) -> Tuple[str, int]:
+        return self.start()
+
+    def __exit__(self, *args):
+        self.shutdown()
+
+
+def run_worker(
+    proto: str,
+    queue_bound_addr: multiprocessing.Queue,
+    hostname: str = "127.0.0.1",
+    port: int = 0,
+) -> None:
+    """
+    Start the dummy proxy server **inside** the current process.
+
+    :param proto: The protocol(s) to handle (e.g., "http", "socks4", etc.).
+        Can be a list using ``+`` as the separator, such as: ``http+socks4``.
+
+    :param queue_bound_addr: A queue that is used as a channel to return the
+        socket address where the server is bound to.
+        This is useful when providing the port ``0`` as the kernel will
+        choose a "random" port number once the socket is created.
+
+    :param port: The port number to listen to.
+    :param hostname: The hostname number to listen to, e.g., 127.0.0.1 or localhost.
+
+    Example Usage:
+
+    >>> import multiprocessing, time
+    >>> from tests.proxy_test_servers.server import run_worker
+    >>>
+    >>> proto = "socks4+socks5+http"
+    >>> callback_queue = multiprocessing.Queue()
+    >>>
+    >>> proc = multiprocessing.Process(
+    ...     target=run_worker,
+    ...     args=(proto, callback_queue),
+    ... )
+    ...
+    >>> proc.start()
+    >>> addr = callback_queue.get()
+    >>> print(f"Listening on: {proto}://{addr[0]}:{addr[1]}")
+    >>>
+    >>> # Keep the server running for 30s.
+    >>> time.sleep(30)
+    >>>
+    >>> # Shutdown
+    >>> proc.terminate()
+    >>> proc.join()
+    """
+    srv = DummyProxyServer(proto, bind_addr=(hostname, port))
+    with srv as bind_addr:
+        queue_bound_addr.put(bind_addr)
+        srv.serve_forever()

--- a/tests/test_dummy_sni_tls_server.py
+++ b/tests/test_dummy_sni_tls_server.py
@@ -4,7 +4,7 @@ from tests.http_test_servers import SNITLSHTTPTestServer
 from tests.utils import get_remote_certificate, create_ssl_context
 
 
-@pytest.mark.enable_socket # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1']) # We need to be able to create the dummy server
 def test_dummy_sni_tls_server(tmp_path):
     """
     Tests that the SNI test server works as expected.

--- a/tests/test_dummy_tls_server.py
+++ b/tests/test_dummy_tls_server.py
@@ -4,7 +4,7 @@ from tests.http_test_servers import TLSTestServer
 from tests.utils import get_remote_certificate, create_ssl_context
 
 
-@pytest.mark.enable_socket # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1']) # We need to be able to create the dummy server
 def test_dummy_tls_server(tmp_path):
     """
     Tests that the test server works expected.

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -66,7 +66,7 @@ def test_blocks_private_ranges(ip_addr: str):
     ],
 )
 @pytest.mark.fake_resolver(enabled=False)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 @mock.patch("urllib3.util.connection.create_connection")
 def test_allows_public_ranges(
     mocked_create_connection: mock.MagicMock,
@@ -164,7 +164,7 @@ def test_allows_public_ranges(
         ),
     ],
 )
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 @mock.patch("urllib3.util.connection.create_connection")
 def test_url_handling(
     mocked_create_connection: mock.MagicMock,
@@ -264,7 +264,7 @@ def test_rejects_non_inet_socket_family():
 
 @pytest.mark.timeout(TEST_TIMEOUT_SECS)
 @pytest.mark.fake_resolver(enabled=True)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_insecure_http_supported():
     """
     Ensure we are able to connect to targets that are using insecure HTTP.
@@ -279,7 +279,7 @@ def test_insecure_http_supported():
 
 @pytest.mark.timeout(TEST_TIMEOUT_SECS)
 @pytest.mark.fake_resolver(enabled=True)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_tls_without_SNIs_supported(tmp_path):
     """
     Ensure we are able to connect successfully to a server that doesn't
@@ -312,7 +312,7 @@ def test_tls_without_SNIs_supported(tmp_path):
 
 @pytest.mark.timeout(TEST_TIMEOUT_SECS)
 @pytest.mark.fake_resolver(enabled=True)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_tls_with_SNIs_supported(tmp_path):
     """
     Ensure we are able to connect successfully to a server that has a
@@ -351,7 +351,7 @@ def test_tls_with_SNIs_supported(tmp_path):
 
 
 @pytest.mark.fake_resolver(enabled=False)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_pass_headers_reference():
     """
     Ensure headers passed to IP filter are not mutated without being copied first.

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -7,40 +7,18 @@ from typing import Tuple
 from unittest import mock
 
 import pytest
-from requests import PreparedRequest
 from requests.exceptions import SSLError
 from urllib3.exceptions import MaxRetryError
 from urllib3.util.ssl_match_hostname import CertificateError
 
-from requests_hardened import Manager, Config
-from .http_test_servers import (
-    InsecureHTTPTestServer,
-    TLSTestServer,
-    SNITLSHTTPTestServer,
-)
-from .utils import mock_getaddrinfo
-
 from requests_hardened.ip_filter import InvalidIPAddress, get_ip_address
 
-# HTTP server can take some time to connect against for some machines (usually up to 1s).
-# It requires a fairly generous timeout without taking too long that the test fails.
-SOCKET_TIMEOUT = (4, 0.1)
+from .http_managers import SSRFFilter, SSRFFilterAllowLocalHost
+from .http_test_servers import (InsecureHTTPTestServer, SNITLSHTTPTestServer,
+                                TLSTestServer)
+from .utils import mock_getaddrinfo
 
 TEST_TIMEOUT_SECS = 5
-
-
-SSRFFilter = Manager(
-    Config(
-        default_timeout=SOCKET_TIMEOUT,
-        never_redirect=False,
-        ip_filter_enable=True,
-        ip_filter_allow_loopback_ips=False,
-        user_agent_override="user-agent",
-    )
-)
-
-SSRFFilterAllowLocalHost = SSRFFilter.clone()
-SSRFFilterAllowLocalHost.config.ip_filter_allow_loopback_ips = True
 
 
 @pytest.mark.parametrize(
@@ -101,9 +79,7 @@ def test_allows_public_ranges(
 
     with dummy_server:
         with mock_getaddrinfo(resolve_to_ip_addr):
-            mocked_create_connection.return_value = (
-                dummy_server.create_client_socket()
-            )
+            mocked_create_connection.return_value = dummy_server.create_client_socket()
             response = SSRFFilter.send_request("GET", "http://test.local")
             mocked_create_connection.assert_called_once()
 
@@ -363,7 +339,7 @@ def test_tls_with_SNIs_supported(tmp_path):
         # it no longer works, which allows to be sure the test is indeed testing SNI.
         with pytest.raises(SSLError) as exc_info:
             http_manager.config.ip_filter_tls_sni_support = False
-            assert do_request()
+            do_request()
 
     exc = exc_info.value.args[0]
     assert isinstance(exc, MaxRetryError)

--- a/tests/test_ssrf_filter_proxy_support.py
+++ b/tests/test_ssrf_filter_proxy_support.py
@@ -1,0 +1,155 @@
+"""
+This test file checks that the proxy support is behaving as expected.
+
+``requests`` and ``urllib3`` only support SOCKS4, SOCKS5, and HTTP proxies,
+thus we are only testing these.
+"""
+
+import functools
+
+import pytest
+from pytest import FixtureRequest
+from requests.exceptions import SSLError
+from urllib3.exceptions import MaxRetryError
+from urllib3.util.ssl_match_hostname import CertificateError
+
+from requests_hardened.ip_filter import InvalidIPAddress
+from tests.http_managers import SSRFFilter, SSRFFilterAllowLocalHost
+from tests.http_test_servers import SNITLSHTTPTestServer, TLSTestServer
+from tests.utils import mock_getaddrinfo
+
+# Lists the supported proxy server protocols.
+# These are the ones supported by `requests[socks]` and `urllib3`.
+SUPPORTED_PROXY_PROTOCOLS = ("socks4", "socks5", "http")
+
+
+@pytest.mark.parametrize(
+    # The protocol to use inside the requests.get(...)
+    "http_client_proto",
+    ("http", "https"),
+)
+@pytest.mark.parametrize(
+    # The protocol to use as the proxy server backend (e.g., SOCKS5)
+    "proxy_proto",
+    SUPPORTED_PROXY_PROTOCOLS,
+)
+def test_proxy_ip_filter_blocks_private(
+    http_client_proto: str, proxy_proto: str, request: FixtureRequest
+):
+    """Ensures private IP addresses are blocked when using proxies."""
+
+    proxy_url = request.getfixturevalue(f"dummy_proxy_{proxy_proto}")
+    proxies = {"https": proxy_url, "http": proxy_proto}
+
+    # Test: ensure IP filter works when the IP address is resolved through DNS.
+    with mock_getaddrinfo("10.0.0.1"):
+        with pytest.raises(InvalidIPAddress, match="10.0.0.1"):
+            SSRFFilter.send_request(
+                "GET",
+                f"{http_client_proto}://example.test",  # Use hostname (DNS)
+                proxies=proxies,
+            )
+
+    # Test: ensure IP filter works when the IP address is in the URL (no DNS).
+    with pytest.raises(InvalidIPAddress, match="127.100.0.2"):
+        SSRFFilter.send_request(
+            "GET",
+            f"{http_client_proto}://127.100.0.2",  # Use IP address (no DNS)
+            proxies=proxies,
+        )
+
+
+@pytest.mark.parametrize(
+    # The protocol to use as the proxy server backend (e.g., SOCKS5)
+    "proxy_proto",
+    SUPPORTED_PROXY_PROTOCOLS,
+)
+@pytest.mark.fake_resolver(enabled=True)
+@pytest.mark.enable_socket  # We need to be able to create the dummy server
+def test_proxy_tls_without_SNIs_supported(
+    proxy_proto: str,
+    request: FixtureRequest,
+    tmp_path,
+):
+    """
+    Ensure we are able to connect successfully to a server that doesn't
+    have a SNI callback set-up when using proxies.
+    """
+
+    proxy_url = request.getfixturevalue(f"dummy_proxy_{proxy_proto}")
+    proxies = {"https": proxy_url, "http": proxy_proto}
+
+    http_manager = SSRFFilterAllowLocalHost.clone()
+    srv = TLSTestServer(
+        tmp_path,
+        cert_identities=["test1.local", "test2.local"],
+    )
+
+    with srv as [_srv_addr, srv_port]:
+        do_request = functools.partial(
+            http_manager.send_request,
+            "GET",
+            f"https://test2.local:{srv_port}",
+            verify=srv.ca_bundle_path,
+            proxies=proxies,
+        )
+
+        # This should work both when SNI support is enabled and disabled.
+        assert do_request().status_code == 200
+
+        # Ensure this test is not testing SNI: when disabling SNI support client-side,
+        # this the HTTP request should still succeed.
+        http_manager.config.ip_filter_tls_sni_support = False
+        assert do_request().status_code == 200
+
+
+@pytest.mark.parametrize(
+    # The protocol to use as the proxy server backend (e.g., SOCKS5)
+    "proxy_proto",
+    SUPPORTED_PROXY_PROTOCOLS,
+)
+@pytest.mark.fake_resolver(enabled=True)
+@pytest.mark.enable_socket  # We need to be able to create the dummy server
+def test_proxy_tls_with_SNIs_supported(
+    proxy_proto: str,
+    request: FixtureRequest,
+    tmp_path,
+):
+    """
+    Ensures when using proxies, we are able to connect successfully to a server
+    that uses SNI callbacks.
+    """
+
+    proxy_url = request.getfixturevalue(f"dummy_proxy_{proxy_proto}")
+    proxies = {"https": proxy_url, "http": proxy_proto}
+
+    http_manager = SSRFFilterAllowLocalHost.clone()
+    srv = SNITLSHTTPTestServer(
+        tmp_path, cert_identities=["localhost"], additional_identities=["sni.local"]
+    )
+
+    with srv as [_srv_addr, srv_port]:
+        do_request = functools.partial(
+            http_manager.send_request,
+            "GET",
+            f"https://sni.local:{srv_port}",
+            verify=srv.ca_bundle_path,
+            proxies=proxies,
+        )
+
+        # This should only work when SNI support is enabled.
+        assert do_request().status_code == 200
+
+        # Ensure when SNI support is disabled client-side, then
+        # it no longer works, which allows to be sure the test is indeed testing SNI.
+        with pytest.raises(SSLError) as exc_info:
+            http_manager.config.ip_filter_tls_sni_support = False
+            do_request()
+
+    exc = exc_info.value.args[0]
+    assert isinstance(exc, MaxRetryError)
+    original_exception = exc.reason.args[0]
+    assert isinstance(original_exception, CertificateError)
+    assert (
+        original_exception.args[0] == "hostname 'sni.local' doesn't match 'localhost'"
+    )

--- a/tests/test_ssrf_filter_proxy_support.py
+++ b/tests/test_ssrf_filter_proxy_support.py
@@ -99,7 +99,7 @@ def test_proxy_tls_without_SNIs_supported(
         assert do_request().status_code == 200
 
         # Ensure this test is not testing SNI: when disabling SNI support client-side,
-        # this the HTTP request should still succeed.
+        # the HTTP request should still succeed.
         http_manager.config.ip_filter_tls_sni_support = False
         assert do_request().status_code == 200
 

--- a/tests/test_ssrf_filter_proxy_support.py
+++ b/tests/test_ssrf_filter_proxy_support.py
@@ -33,7 +33,7 @@ SUPPORTED_PROXY_PROTOCOLS = ("socks4", "socks5", "http")
     "proxy_proto",
     SUPPORTED_PROXY_PROTOCOLS,
 )
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_proxy_ip_filter_blocks_private(
     http_client_proto: str, proxy_proto: str, request: FixtureRequest
 ):
@@ -66,7 +66,7 @@ def test_proxy_ip_filter_blocks_private(
     SUPPORTED_PROXY_PROTOCOLS,
 )
 @pytest.mark.fake_resolver(enabled=True)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_proxy_tls_without_SNIs_supported(
     proxy_proto: str,
     request: FixtureRequest,
@@ -110,7 +110,7 @@ def test_proxy_tls_without_SNIs_supported(
     SUPPORTED_PROXY_PROTOCOLS,
 )
 @pytest.mark.fake_resolver(enabled=True)
-@pytest.mark.enable_socket  # We need to be able to create the dummy server
+@pytest.mark.allow_hosts(['127.0.0.1'])  # We need to be able to create the dummy server
 def test_proxy_tls_with_SNIs_supported(
     proxy_proto: str,
     request: FixtureRequest,

--- a/tests/test_ssrf_filter_proxy_support.py
+++ b/tests/test_ssrf_filter_proxy_support.py
@@ -40,7 +40,7 @@ def test_proxy_ip_filter_blocks_private(
     """Ensures private IP addresses are blocked when using proxies."""
 
     proxy_url = request.getfixturevalue(f"dummy_proxy_{proxy_proto}")
-    proxies = {"https": proxy_url, "http": proxy_proto}
+    proxies = {"https": proxy_url, "http": proxy_url}
 
     # Test: ensure IP filter works when the IP address is resolved through DNS.
     with mock_getaddrinfo("10.0.0.1"):
@@ -78,7 +78,7 @@ def test_proxy_tls_without_SNIs_supported(
     """
 
     proxy_url = request.getfixturevalue(f"dummy_proxy_{proxy_proto}")
-    proxies = {"https": proxy_url, "http": proxy_proto}
+    proxies = {"https": proxy_url, "http": proxy_url}
 
     http_manager = SSRFFilterAllowLocalHost.clone()
     srv = TLSTestServer(
@@ -122,7 +122,7 @@ def test_proxy_tls_with_SNIs_supported(
     """
 
     proxy_url = request.getfixturevalue(f"dummy_proxy_{proxy_proto}")
-    proxies = {"https": proxy_url, "http": proxy_proto}
+    proxies = {"https": proxy_url, "http": proxy_url}
 
     http_manager = SSRFFilterAllowLocalHost.clone()
     srv = SNITLSHTTPTestServer(

--- a/tests/test_ssrf_filter_proxy_support.py
+++ b/tests/test_ssrf_filter_proxy_support.py
@@ -33,6 +33,7 @@ SUPPORTED_PROXY_PROTOCOLS = ("socks4", "socks5", "http")
     "proxy_proto",
     SUPPORTED_PROXY_PROTOCOLS,
 )
+@pytest.mark.enable_socket  # We need to be able to create the dummy server
 def test_proxy_ip_filter_blocks_private(
     http_client_proto: str, proxy_proto: str, request: FixtureRequest
 ):


### PR DESCRIPTION
This officially adds support for proxies (SOCKS4, SOCKS5, HTTP, and HTTPS) by adding tests and documentation in order to ensure ongoing support.

Prior to v1.0.0b5 (via https://github.com/saleor/requests-hardened/pull/29), SSL/TLS was not working when using proxies but it was accidentally fixed.

_Internal task: https://linear.app/saleor/issue/SEC-72/_