### PR TITLE
feat: add official support for HTTP redirect in SSRF filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Features
 ========
 
 - `SSRF Filters`_: blocks private and loopback IP ranges.
+- HTTP Redirects: can be used safely alongside the SSRF filter feature.
 - `Proxy Support`_: proxies can be used in combination with SSRF Filters for a defense in depth.
 - Handy `Overrides of Defaults`_: allows to enforce secure defaults globally, such as to
   mitigate DoS attacks.

--- a/tests/http_test_servers/insecure.py
+++ b/tests/http_test_servers/insecure.py
@@ -1,10 +1,10 @@
 import socket
-from typing import Tuple, Optional
 import threading
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional, Tuple, Type
 
 
-class HTTPRequestHandler(BaseHTTPRequestHandler):
+class DefaultHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_HEAD(self):
         self.send_response(code=200)
         self.send_header("Connection", "close")
@@ -31,15 +31,19 @@ class InsecureHTTPTestServer:
         Connect to http://localhost:12345
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        request_handler_class: Type[BaseHTTPRequestHandler] = DefaultHTTPRequestHandler,
+    ):
         self.server: Optional[HTTPServer] = None
         self.server_thread: Optional[threading.Thread] = None
+        self._http_request_handler = request_handler_class
 
     def setup_server(self, server: HTTPServer) -> None:
         pass
 
     def start(self) -> Tuple[str, int]:
-        self.server = HTTPServer(("localhost", 0), HTTPRequestHandler)
+        self.server = HTTPServer(("localhost", 0), self._http_request_handler)
         self.setup_server(self.server)
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()

--- a/tests/http_test_servers/utils/http_redirects.py
+++ b/tests/http_test_servers/utils/http_redirects.py
@@ -1,0 +1,46 @@
+from http.server import BaseHTTPRequestHandler
+from typing import Type
+
+
+class RedirectRequestHandler(BaseHTTPRequestHandler):
+    redirect_url_loc: str
+
+
+def create_http_redirect_handler(redirect_url: str) -> Type[RedirectRequestHandler]:
+    """
+    Create an ``http.server`` request handler that redirects to the given url.
+
+    To prevent redirection loops, ``noredirect`` can be provided anywhere inside the
+    request URL to stop redirections.
+
+    :param redirect_url: The URL to redirect to.
+    :return: The HTTP request handler that redirects to the given url.
+    """
+
+    class _Handler(RedirectRequestHandler):
+        redirect_url_loc = redirect_url
+
+        @property
+        def should_redirect(self) -> bool:
+            return "noredirect" not in self.path
+
+        def do_HEAD(self):
+            if self.should_redirect:
+                self.send_response(code=301)
+                self.send_header("Location", self.redirect_url_loc)
+            else:
+                self.send_response(code=200)
+
+            self.send_header("Connection", "close")
+            self.end_headers()
+
+        def do_GET(self):
+            self.do_HEAD()
+            if self.should_redirect:
+                self.wfile.write(
+                    b"Redirecting to %b\n" % self.redirect_url_loc.encode()
+                )
+            else:
+                self.wfile.write(b"OK")
+
+    return _Handler


### PR DESCRIPTION
This officially adds support for HTTP redirects inside the SSRF filter by adding tests and documentation to ensure the behavior is expected and remains unchanged over time.

Closes #12 