### PR TITLE
release: v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     "Saleor Commerce <hello@saleor.io>"
 ]
 license = "BSD-3-Clause"
-version = "1.0.0"
+version = "1.1.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
This bumps the library version to v1.1.0, changes:

- Updated all dependencies to their latest version
- Fixed an issue where the `cryptography` library was always outdated
- Removed support for PyPy 3.9 as it is no longer supported/latest
- Added PyPy 3.11 (latest)
- Fixed a typing error (mypy)