### PR TITLE
fix: upgrade GitHub artifact actions

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -40,7 +40,7 @@ jobs:
         run: python3 -m poetry build -f sdist -o ./dist
 
       - name: Upload Build
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "dist"
           path: "dist/"
@@ -58,7 +58,7 @@ jobs:
       id-token: write  # Required for PyPI trusted publishing
 
     steps:
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: dist
           path: dist


### PR DESCRIPTION
v3 versions of `upload-artifact` & `download-artifact` are no longer supported (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) thus workflow was failing.