### PR TITLE
fix: publish wheels on PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -17,7 +17,7 @@ env:
   POETRY_VIRTUALENVS_CREATE: "false"
 
 jobs:
-  build_sdist:
+  build:
     runs-on: ubuntu-22.04
 
     permissions:
@@ -30,14 +30,14 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
-          python-version-file: '.github/requirements/.python_version'
+          python-version-file: ".github/requirements/.python_version"
 
       - name: Install Dependencies
         run: |
           python -m pip install "poetry==$(cat .github/requirements/.poetry_version)"
 
       - name: Build
-        run: python3 -m poetry build -f sdist -o ./dist
+        run: python3 -m poetry build -o ./dist
 
       - name: Upload Build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -52,10 +52,10 @@ jobs:
     environment: publish-pypi
 
     needs:
-      - build_sdist
+      - build
 
     permissions:
-      id-token: write  # Required for PyPI trusted publishing
+      id-token: write # Required for PyPI trusted publishing
 
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     "Saleor Commerce <hello@saleor.io>"
 ]
 license = "BSD-3-Clause"
-version = "1.1.0"
+version = "1.1.1"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
This fixes an issue where the library was only publishing the source code (`sdist`) in PyPI instead of also including the wheels as explained at https://github.com/saleor/requests-hardened/pull/47#issuecomment-3247894036.

Closes #47 (due to refusal to sign CLA, thus I rewrote the PR from scratch)

Example:
- Wheel being added (this PR's fix): https://test.pypi.org/project/requests-hardened/1.1.1/#files
- Missing wheels: https://pypi.org/project/requests-hardened/1.1.0/#files