### PR TITLE
fix: test failures

### DIFF
--- a/requests_hardened/ip_filter.py
+++ b/requests_hardened/ip_filter.py
@@ -11,12 +11,21 @@ from urllib3.util.connection import (  # type: ignore[attr-defined] # `allowed_g
 logger = logging.getLogger(__name__)
 
 # Additional CIDRs that should be blocked
-EXTRA_BLOCKED_NET_RANGES: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+EXTRA_BLOCKED_NET_RANGES: tuple[
+    Union[ipaddress.IPv4Network, ipaddress.IPv6Network], ...
+] = (
     ipaddress.ip_network("192.88.99.0/24"),  # 6to4 relay anycast
     ipaddress.ip_network("100.64.0.0/10"),  # CG-NAT, can route to internal workloads
     ipaddress.ip_network("5f00::/16"),  # IPv6 Segment Routing
     ipaddress.ip_network("64:ff9b::/96"),  # used for IPv6 & IPv4 translation (NAT64)
     ipaddress.ip_network("2001:20::/28"),  # ORCHIDv2 (overlay identifiers)
+
+    # Fixes https://github.com/python/cpython/issues/113171 for outdated CPython
+    # installations.
+    ipaddress.ip_network("192.0.0.0/24"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+    ipaddress.ip_network("2002::/16"),
+    ipaddress.ip_network("3fff::/20"),
 )
 
 
@@ -25,7 +34,7 @@ class InvalidIPAddress(requests.RequestException):
 
 
 def _is_ip_in_extra_blocked_ranges(
-    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    ip: Union[ipaddress.IPv4Address, ipaddress.IPv6Address],
 ) -> bool:
     """Checks whether a given IP is part of the additional disallowed ranges."""
 


### PR DESCRIPTION
Fixes issues with CI/CD after merge of b7403f88d3b3689e57435b75b51691a160aaeef5.

Changes:
- Fixed incompatibility with older Python versions due to using newer union type hints (`|` instead of `Union`)
- Fixed test failures caused by `actions/setup-python` - MacOS and Windows workflows are installing `3.11.9` and `3.10.11` instead of `3.11.15` and `3.10.20` which means they are behind a few CPython CVE fixes thus leading to the test failing SSRF bypasses. As this requires Microsoft to update their actions, we are mitigating the issue by explicitly blocking these ranges. We do not recommend anyone to use these CPython outdated versions in production, nor do we provide any guarantee that our CPython mitigations for `3.11.9` and `3.10.11` are complete.