### PR TITLE
fix: headers being case-sensitive

### DIFF
--- a/requests_hardened/client.py
+++ b/requests_hardened/client.py
@@ -47,5 +47,5 @@ class HTTPSession(requests.Session):
 
     def prepare_request(self, request: Request) -> PreparedRequest:
         if self._config.user_agent_override is not None:
-            request.headers.update({"User-Agent": self._config.user_agent_override})
+            request.headers["User-Agent"] = self._config.user_agent_override
         return super().prepare_request(request)

--- a/requests_hardened/ip_filter_adapter.py
+++ b/requests_hardened/ip_filter_adapter.py
@@ -1,4 +1,7 @@
+from typing import Union
+import requests
 from requests.adapters import HTTPAdapter
+from requests.structures import CaseInsensitiveDict
 from requests_hardened.ip_filter import filter_host
 
 
@@ -20,7 +23,12 @@ class IPFilterAdapter(HTTPAdapter):
         self._allow_loopback = allow_loopback
         self._tls_sni_support = tls_sni_support
 
-    def build_connection_pool_key_attributes(self, request, verify, cert=None):
+    def build_connection_pool_key_attributes(
+        self,
+        request: requests.PreparedRequest,
+        verify: Union[bool, str],
+        cert: Union[str, tuple[str, str], None] = None,
+    ):
         host_params, pool_kwargs = super().build_connection_pool_key_attributes(
             request, verify, cert
         )
@@ -29,9 +37,9 @@ class IPFilterAdapter(HTTPAdapter):
         # subsequent requests.
         # e.g., https://github.com/lepture/authlib/blob/a7d68b4c3b8a3a7fe0b62943b5228669f2f3dfec/authlib/oauth2/client.py#L205-L206
         if request.headers:
-            request.headers = dict(**request.headers)
+            request.headers = CaseInsensitiveDict(request.headers)
         else:
-            request.headers = {}
+            request.headers = CaseInsensitiveDict()
 
         # Adds the original URL hostname as the 'Host' header.
         original_host = request.headers["Host"] = host_params["host"]

--- a/tests/http_managers.py
+++ b/tests/http_managers.py
@@ -4,13 +4,15 @@ from requests_hardened import Config, Manager
 # It requires a fairly generous timeout without taking too long that the test fails.
 SOCKET_TIMEOUT = (4, 0.1)
 
+DEFAULT_TEST_USER_AGENT = "user-agent"
+
 SSRFFilter = Manager(
     Config(
         default_timeout=SOCKET_TIMEOUT,
         never_redirect=False,
         ip_filter_enable=True,
         ip_filter_allow_loopback_ips=False,
-        user_agent_override="user-agent",
+        user_agent_override=DEFAULT_TEST_USER_AGENT,
     )
 )
 

--- a/tests/test_override_user_agent_header.py
+++ b/tests/test_override_user_agent_header.py
@@ -1,11 +1,10 @@
 from unittest import mock
 
 import pytest
-
 import requests
+from requests.utils import default_headers
 
-from requests_hardened import Manager, Config
-
+from requests_hardened import Config, Manager
 
 UserAgentNotDefinedManager = Manager(
     Config(
@@ -50,3 +49,35 @@ def test_user_agent_override_undefined(mocked_send: mock.MagicMock):
     prep_request = mocked_send.call_args[0][0]
     assert mocked_send.assert_called_once
     assert prep_request.headers.get("User-Agent") == f"python-requests/{requests.__version__}"
+
+
+@mock.patch("requests.sessions.Session.send")
+@pytest.mark.parametrize(
+    "user_agent_header_name",
+    [
+        "User-Agent",  # title case
+        "User-AGENT",  # mixed case
+        "USER-AGENT",  # all caps
+        "user-agent",  # lowercase
+    ],
+)
+def test_user_agent_header_is_case_insensitive(
+    mocked_send: mock.MagicMock,
+    user_agent_header_name: str,
+):
+    http_manager = UserAgentNotDefinedManager.clone()
+    http_manager.config.user_agent_override = "My custom UA"
+
+    input_headers = {user_agent_header_name: "This value should be overriden"}
+    expected_headers = default_headers()
+    expected_headers["User-Agent"] = "My custom UA"
+
+    http_manager.send_request(
+        "GET",
+        "https://example.com",
+        headers=input_headers,
+    )
+
+    prep_request = mocked_send.call_args[0][0]
+    assert mocked_send.assert_called_once
+    assert prep_request.headers == expected_headers

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -3,17 +3,19 @@ import ipaddress
 import socket
 import sys
 from socket import AddressFamily, SocketKind
-from typing import Iterator, Tuple
+from typing import Iterator, Mapping, Tuple
 from unittest import mock
 
 import pytest
 from requests.exceptions import SSLError
+from requests.structures import CaseInsensitiveDict
+from requests.utils import default_headers
 from urllib3.exceptions import MaxRetryError
 from urllib3.util.ssl_match_hostname import CertificateError
 
 from requests_hardened.ip_filter import InvalidIPAddress, get_ip_address
 
-from .http_managers import SSRFFilter, SSRFFilterAllowLocalHost
+from .http_managers import DEFAULT_TEST_USER_AGENT, SSRFFilter, SSRFFilterAllowLocalHost
 from .http_test_servers import (
     InsecureHTTPTestServer,
     SNITLSHTTPTestServer,
@@ -21,7 +23,6 @@ from .http_test_servers import (
 )
 from .http_test_servers.utils.http_redirects import create_http_redirect_handler
 from .utils import mock_getaddrinfo
-
 
 IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
 
@@ -448,6 +449,56 @@ def test_pass_headers_reference():
     assert (
         response.request.headers.get("foo") == "bar"
     ), "Should have preserved the original headers"
+
+
+
+@pytest.mark.fake_resolver(enabled=False)
+@pytest.mark.allow_hosts(["127.0.0.1"])  # We need to be able to create the dummy server
+@pytest.mark.parametrize(
+    ("_case", "input_headers", "expected_headers"),
+    [
+        (
+            # When a custom value is provided in 'Host', then it should replace it
+            # with the URL's hostname instead
+            "Custom host header should be dropped",
+            {"HoST": "foo.local"},
+            {
+                **default_headers(),
+                "Host": "dummy.local",
+                "User-Agent": DEFAULT_TEST_USER_AGENT,
+            },
+        ),
+        (
+            # When passing custom headers and the library doesn't have an override
+            # for it (i.e., when not providing 'User-Agent' or 'Host'), then it should
+            # not touch the headers
+            "Non-overridden headers should be kept",
+            {"x-forwarded-for": "127.0.0.1", "AUTHORIZATION": "Bearer Foo"},
+            {
+                **default_headers(),
+                "x-forwarded-for": "127.0.0.1",
+                "AUTHORIZATION": "Bearer Foo",
+                "Host": "dummy.local",
+                "User-Agent": DEFAULT_TEST_USER_AGENT,
+            },
+        ),
+    ],
+)
+def test_headers_are_case_insensitive(
+    _case: str, input_headers: Mapping[str, str], expected_headers: CaseInsensitiveDict
+):
+    dummy_server = InsecureHTTPTestServer()
+
+    http_manager = SSRFFilter.clone()
+    http_manager.config.ip_filter_allow_loopback_ips = True
+
+    with dummy_server as [host, port]:
+        url = f"http://dummy.local:{port}/"
+        with mock_getaddrinfo(host):
+            response = http_manager.send_request("GET", url, headers=input_headers)
+
+    actual_headers = response.request.headers
+    assert actual_headers == expected_headers
 
 
 @pytest.mark.allow_hosts(["127.0.0.1"])  # We need to be able to create the dummy server


### PR DESCRIPTION
This fixes a bug where headers were being case-sensitive instead of being case-insensitive which could lead to duplicate headers thus leading to crashes. This could happen both for `Host` and `User-Agent` headers.

Closes #59