### PR TITLE
fix: missing port and wrong IPv6 values in Host headers

### DIFF
--- a/src/requests_hardened/ip_filter_adapter.py
+++ b/src/requests_hardened/ip_filter_adapter.py
@@ -41,8 +41,22 @@ class IPFilterAdapter(HTTPAdapter):
         else:
             request.headers = CaseInsensitiveDict()
 
+        # Retrieves the hostname or IP to resolve
+        original_hostname = host_params["host"]
+        host_header = original_hostname
+
+        # If the hostname is an IPv6 value, then we wrap the ``Host`` header
+        # with brackets (e.g., ``::1`` -> ``[::1]``)
+        # We only check if a colon (':') is present in the string as means it's
+        # an IPv6 address as hostnames cannot contain colons
+        if ":" in host_header:
+            host_header = f"[{host_header}]"
+
+        if (port := host_params["port"]) is not None:
+            host_header += f":{port}"
+
         # Adds the original URL hostname as the 'Host' header.
-        original_host = request.headers["Host"] = host_params["host"]
+        request.headers["Host"] = host_header
 
         # Set the original hostname for certificate validation otherwise
         # urllib3 will try to match the pinned resolved IP address against the
@@ -51,19 +65,24 @@ class IPFilterAdapter(HTTPAdapter):
         # Note: assert_hostname and server_hostname cannot be passed
         #       when using insecure HTTP (http://) as it's not a valid argument for
         #       `urllib3.connectionpool.HTTPConnectionPool`.
+        #
+        # Note: SAN (Subject Alternative Name), and SNI do not use ports as
+        #       they define the hostname values as a DNS hostname.
+        #       For SNI, see: https://datatracker.ietf.org/doc/html/rfc6066#section-3
+        #       For SAN, see: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
         if self._is_https_proto is True:
             # For non-TLS SNI servers.
-            pool_kwargs["assert_hostname"] = original_host  # type: ignore[typeddict-unknown-key] # Valid parameter for urllib3.connectionpool.HTTPSConnectionPool
+            pool_kwargs["assert_hostname"] = original_hostname  # type: ignore[typeddict-unknown-key] # Valid parameter for urllib3.connectionpool.HTTPSConnectionPool
 
             # Support TLS servers with SNI callbacks.
             if self._tls_sni_support is True:
-                pool_kwargs["server_hostname"] = original_host  # type: ignore[typeddict-unknown-key] # Valid parameter for urllib3.connectionpool.HTTPSConnectionPool
+                pool_kwargs["server_hostname"] = original_hostname  # type: ignore[typeddict-unknown-key] # Valid parameter for urllib3.connectionpool.HTTPSConnectionPool
 
         # Override the connection hostname to the resolved IP address,
         # and reject if it's a private IP.
         host_params["host"] = filter_host(
-            original_host,
-            host_params["port"],
+            original_hostname,
+            port,
             allow_loopback=self._allow_loopback,
         )
         return host_params, pool_kwargs

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -473,9 +473,19 @@ def test_pass_headers_reference():
             "dummy-http.test:8888",
         ),
         (
-            "Using IP address + custom port, should set the correct Host header",
+            "Using IPv4 address + custom port, should set the correct Host header",
             "http://8.8.8.0:8888/",
             "8.8.8.0:8888",
+        ),
+        (
+            "Using IPv6 address + custom port, should set the correct Host header",
+            "http://[2606:4700:10::6814:179a]:8888/",
+            "[2606:4700:10::6814:179a]:8888",
+        ),
+        (
+            "Using compressed IPv6 address + custom port, should set the correct Host header",
+            "http://[::1]:8888/",
+            "[::1]:8888",
         ),
     ],
 )

--- a/tests/test_ssrf_filter.py
+++ b/tests/test_ssrf_filter.py
@@ -197,7 +197,7 @@ def test_allows_public_ranges(
             "http://[2004:0db8:1234:5678::abcd:ef01]/",
             "2004:0db8:1234:5678::abcd:ef01",
             ("2004:db8:1234:5678::abcd:ef01", 80),
-            "2004:0db8:1234:5678::abcd:ef01",
+            "[2004:0db8:1234:5678::abcd:ef01]",
         ),
         (
             # Ensure ports are handled properly
@@ -205,7 +205,7 @@ def test_allows_public_ranges(
             "http://[2004:0db8:1234:5678::abcd:ef01]:444/",
             "2004:0db8:1234:5678::abcd:ef01",
             ("2004:db8:1234:5678::abcd:ef01", 444),
-            "2004:0db8:1234:5678::abcd:ef01",
+            "[2004:0db8:1234:5678::abcd:ef01]:444",
         ),
         (
             # Ensure ports are handled properly
@@ -213,7 +213,7 @@ def test_allows_public_ranges(
             "http://[2004:0db8:1234:5678::abcd:ef01]:444/",
             "2004:0db8:1234:5678::abcd:ef01",
             ("2004:db8:1234:5678::abcd:ef01", 444),
-            "2004:0db8:1234:5678::abcd:ef01",
+            "[2004:0db8:1234:5678::abcd:ef01]:444",
         ),
         (
             # Ensure ports are handled properly
@@ -221,7 +221,7 @@ def test_allows_public_ranges(
             "http://127.0.0.1:444/",
             "127.0.0.1",
             ("127.0.0.1", 444),
-            "127.0.0.1",
+            "127.0.0.1:444",
         ),
         (
             # Ensure ports are handled properly
@@ -229,7 +229,7 @@ def test_allows_public_ranges(
             "http://example.com:444/",
             "127.0.0.1",
             ("127.0.0.1", 444),
-            "example.com",
+            "example.com:444",
         ),
         (
             # Ensure unicode URLs are encoded to IDNA
@@ -273,9 +273,9 @@ def test_url_handling(
     # especially not a URL hostname.
     # We should always only resolve once as otherwise we risk race-condition
     # vulnerabilities, or bypass through malicious DNS round-robin.
-    assert conn_addr == (
-        expected_sock_addr
-    ), "Should have passed the mocked getaddrinfo() IP address"
+    assert conn_addr == (expected_sock_addr), (
+        "Should have passed the mocked getaddrinfo() IP address"
+    )
 
 
 @pytest.mark.parametrize(
@@ -445,11 +445,65 @@ def test_pass_headers_reference():
     assert response.request.method == "GET"
     assert response.request.url == url
     assert "Host" not in input_headers, "Shouldn't have mutated the input headers"
-    assert response.request.headers.get("Host") == "dummy.local"
-    assert (
-        response.request.headers.get("foo") == "bar"
-    ), "Should have preserved the original headers"
+    assert response.request.headers.get("Host") == f"dummy.local:{port}"
+    assert response.request.headers.get("foo") == "bar", (
+        "Should have preserved the original headers"
+    )
 
+
+@pytest.mark.fake_resolver(enabled=False)
+@pytest.mark.allow_hosts(["127.0.0.1"])  # We need to be able to create the dummy server
+@mock.patch("urllib3.util.connection.create_connection")
+@pytest.mark.parametrize(
+    ("_case", "input_url", "expected_host_header"),
+    [
+        (
+            "No port provided -> shouldn't set any port in Host header",
+            "http://dummy-http.test/",
+            "dummy-http.test",
+        ),
+        (
+            "Default HTTP port provided -> should set the port in Host header",
+            "http://dummy-http.test:80/",
+            "dummy-http.test:80",
+        ),
+        (
+            "Non-Default port provided",
+            "http://dummy-http.test:8888/",
+            "dummy-http.test:8888",
+        ),
+        (
+            "Using IP address + custom port, should set the correct Host header",
+            "http://8.8.8.0:8888/",
+            "8.8.8.0:8888",
+        ),
+    ],
+)
+def test_sets_port_number_in_host_header(
+    mocked_create_connection: mock.MagicMock,
+    _case: str,
+    input_url: str,
+    expected_host_header: str,
+):
+    """
+    Ensure the ``Host`` header includes the port number when a port is
+    explicitly provided.
+    """
+
+    dummy_server = InsecureHTTPTestServer()
+
+    http_manager = SSRFFilter.clone()
+    http_manager.config.ip_filter_allow_loopback_ips = True
+
+    with dummy_server:
+        with mock_getaddrinfo("127.0.0.1"):
+            mocked_create_connection.return_value = dummy_server.create_client_socket()
+            response = http_manager.send_request("GET", input_url)
+            mocked_create_connection.assert_called_once()
+
+    assert response.request.method == "GET"
+    assert response.request.url == input_url
+    assert response.request.headers.get("Host") == expected_host_header
 
 
 @pytest.mark.fake_resolver(enabled=False)
@@ -497,6 +551,8 @@ def test_headers_are_case_insensitive(
         with mock_getaddrinfo(host):
             response = http_manager.send_request("GET", url, headers=input_headers)
 
+    expected_headers["Host"] += f":{port}"
+
     actual_headers = response.request.headers
     assert actual_headers == expected_headers
 
@@ -529,7 +585,7 @@ def test_http_redirect_should_not_affect_request_headers():
             )
 
             # A new Host header value should be set on redirect.
-            assert response.request.headers.get("Host") == "redirected.local"
+            assert response.request.headers.get("Host") == f"redirected.local:{port}"
 
             # Ensure the Authorization header is dropped when redirected.
             # This is dictated by:


### PR DESCRIPTION
Fixes two bugs:
1. Port number was missing in `Host` headers when provided explicitly by the user, e.g., `http://127.0.0.1:8005` was sending `Host: 127.0.0.1` instead of `Host: 127.0.0.1:8005`
2. `Host` headers were missing bracked when the URL connects to an IPv6 URL, e.g., `http://[::1]` was sending `Host: ::1` whereas it should have sent `Host: [::1]`. Likewise, the port number was getting lost, e.g., when passing `http://[::1]:8005`, it should then pass `Host: [::1]:8005`

   This can also be observed in Firefox for example:

   - Behavior when passing without a port number with an IPv6 hostname: <br><img width="400"  alt="2026-06-15_18-06-11_095279235" src="https://github.com/user-attachments/assets/5ec4639a-dd12-481d-b09b-8f2bd881dafa" />
  

   - Behavior when passing a port: <br><img width="400"  alt="2026-06-15_18-05-44_999369329" src="https://github.com/user-attachments/assets/14bcba9a-0b62-4086-ae56-9a62f83f9932" />
